### PR TITLE
Change page when swiping left and right

### DIFF
--- a/guten_reader_FE/Components/Reader/Reader.js
+++ b/guten_reader_FE/Components/Reader/Reader.js
@@ -4,26 +4,41 @@ import { createAppContainer } from 'react-navigation';
 import { createStackNavigator } from 'react-navigation-stack';
 import MusicMenu from '../MusicMenu/MusicMenu';
 import { withNavigation } from 'react-navigation';
+import GestureRecognizer, {swipeDirections} from 'react-native-swipe-gestures';
 
 class Reader extends React.Component {
 
   constructor() {
     super();
     this.state = {
-      currentPage: null
+      currentPage: 0
     }
+  }
+
+  onSwipeLeft(gestureState) {
+    this.setState(prevState => {
+       return {currentPage: prevState.currentPage + 1}
+    });
+  }
+
+  onSwipeRight(gestureState) {
+    this.setState({
+      currentPage: this.state.currentPage - 1
+    });
   }
 
   render() {
     const bookText = this.props.navigation.getParam('bookText', 'ERROR')
     return (
+      <GestureRecognizer onSwipeLeft={this.onSwipeLeft.bind(this)} onSwipeRight={this.onSwipeRight.bind(this)}>
         <ScrollView>
           <View style={styles.container}>
-            <Text style={styles.mockText}>{bookText[3]}</Text>
+            <Text style={styles.mockText}>{bookText[this.state.currentPage]}</Text>
             <Button style={styles.button} onPress={() => this.props.navigation.navigate('Library')} title="BACK"></Button>
             <MusicMenu />
           </View>
         </ScrollView>
+      </GestureRecognizer>
     );
   }
 }

--- a/guten_reader_FE/package.json
+++ b/guten_reader_FE/package.json
@@ -15,6 +15,7 @@
     "react-native-gesture-handler": "^1.5.2",
     "react-native-material-ui": "^1.30.1",
     "react-native-splash-screen": "^3.2.0",
+    "react-native-swipe-gestures": "^1.0.4",
     "react-native-vector-icons": "^6.6.0",
     "react-native-video": "^5.0.2",
     "react-native-web": "~0.11.7",


### PR DESCRIPTION
Title: page-swipe - Swipe through book pages
## Issue Number: #32 
### Description of Behavior
When swiping left and right on the Reader component, the index of the array inc or dec by 1, therefore displaying the next or prev page.
### Pull request checklist
Please check if your PR fulfills the following requirements:
- [ ] Tests are written
- [ ] Test coverage acceptable
- [ ] Sad paths accounted for
- [ ] Tested in browser 
### Merge to
- [x] Development branch
- [ ] Staging branch
- [ ] Master
### Additional Comments
Currently, all the pages of the book are being stored in an array that is being passed through navigation and stored in the render. This pages array should probably be stored in state instead of in the render, but I have been unable to do that and have the functionality of the page text actually displaying remain.